### PR TITLE
feta: Member metadata facts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,7 @@
 		"unregister",
 		"unregisters",
 		"uuid",
+		"uvarint",
 		"vcfg",
 		"veth",
 		"vishvananda",

--- a/apply/state_test.go
+++ b/apply/state_test.go
@@ -65,6 +65,7 @@ func TestPeerConfigState_Update(t *testing.T) {
 		aliveUntil time.Time
 		bootID     *uuid.UUID
 		now        time.Time
+		facts      []*fact.Fact
 	}
 	tests := []struct {
 		name   string
@@ -195,7 +196,7 @@ func TestPeerConfigState_Update(t *testing.T) {
 			if tt.fields.nil {
 				pcs = nil
 			}
-			got := pcs.Update(tt.args.peer, tt.args.name, tt.args.newAlive, tt.args.aliveUntil, tt.args.bootID, tt.args.now)
+			got := pcs.Update(tt.args.peer, tt.args.name, tt.args.newAlive, tt.args.aliveUntil, tt.args.bootID, tt.args.now, tt.args.facts)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/config/peer-config-set.go
+++ b/config/peer-config-set.go
@@ -18,12 +18,12 @@ func (p Peers) Has(peer wgtypes.Key) bool {
 	return ok && val != nil
 }
 
-// Name returns the name of the peer, if configured, or else its key string
+// Name returns the name of the peer, if configured, or else the empty string
 func (p Peers) Name(peer wgtypes.Key) string {
-	if config, ok := p[peer]; ok && len(config.Name) > 0 {
+	if config := p[peer]; config != nil {
 		return config.Name
 	}
-	return peer.String()
+	return ""
 }
 
 // Trust returns the configured trust level (if present and valid) or else the

--- a/config/peer-config-set_test.go
+++ b/config/peer-config-set_test.go
@@ -26,9 +26,9 @@ func TestPeers_Name(t *testing.T) {
 		args args
 		want string
 	}{
-		{"nil peers", nil, args{k1}, k1.String()},
-		{"empty peers", make(Peers), args{k1}, k1.String()},
-		{"other peer", Peers{k2: &Peer{Name: "xyzzy"}}, args{k1}, k1.String()},
+		{"nil peers", nil, args{k1}, ""},
+		{"empty peers", make(Peers), args{k1}, ""},
+		{"other peer", Peers{k2: &Peer{Name: "xyzzy"}}, args{k1}, ""},
 		{"named peer", Peers{k1: &Peer{Name: "xyzzy"}}, args{k1}, "xyzzy"},
 	}
 	for _, tt := range tests {

--- a/fact/fact.go
+++ b/fact/fact.go
@@ -15,13 +15,14 @@ import (
 
 // fact types, denoted as attributes of a subject
 const (
-	AttributeUnknown       Attribute = 0
-	AttributeAlive         Attribute = '!'
-	AttributeEndpointV4    Attribute = 'e'
-	AttributeEndpointV6    Attribute = 'E'
-	AttributeAllowedCidrV4 Attribute = 'a'
-	AttributeAllowedCidrV6 Attribute = 'A'
-	AttributeMember        Attribute = 'm'
+	AttributeUnknown        Attribute = 0
+	AttributeAlive          Attribute = '!'
+	AttributeEndpointV4     Attribute = 'e'
+	AttributeEndpointV6     Attribute = 'E'
+	AttributeAllowedCidrV4  Attribute = 'a'
+	AttributeAllowedCidrV6  Attribute = 'A'
+	AttributeMember         Attribute = 'm'
+	AttributeMemberMetadata Attribute = 'M'
 	// A signed group is a bit different from other facts
 	// in this case, the subject is actually the source,
 	// and the value is a signed aggregate of other facts.

--- a/fact/member-metadata.go
+++ b/fact/member-metadata.go
@@ -105,3 +105,31 @@ func (mm *MemberMetadata) String() string {
 	}
 	return ret.String()
 }
+
+// Has returns whether the given MemberAttribute is present in the metadata
+func (mm *MemberMetadata) Has(attr MemberAttribute) bool {
+	_, ok := mm.attributes[attr]
+	return ok
+}
+
+// Get returns the given MemberAttribute or the empty string if not present
+func (mm *MemberMetadata) Get(attr MemberAttribute) string {
+	return mm.attributes[attr]
+}
+
+// TryGet returns the given MemberAttribute or the empty string,
+// and whether or not it was present.
+func (mm *MemberMetadata) TryGet(attr MemberAttribute) (string, bool) {
+	val, ok := mm.attributes[attr]
+	return val, ok
+}
+
+// BuildMemberMetadata creates a metadata structure with the MemberName
+// attribute set to the given value.
+func BuildMemberMetadata(name string) *MemberMetadata {
+	return &MemberMetadata{
+		attributes: map[MemberAttribute]string{
+			MemberName: name,
+		},
+	}
+}

--- a/fact/member-metadata.go
+++ b/fact/member-metadata.go
@@ -107,10 +107,12 @@ func (mm *MemberMetadata) String() string {
 		break
 	}
 	if len(mm.attributes) > 1 {
-		fmt.Fprintf(ret, ",%d more", len(mm.attributes)-1)
+		fmt.Fprintf(ret, ",+%d", len(mm.attributes)-1)
 	}
 	return ret.String()
 }
+
+/*
 
 // Has returns whether the given MemberAttribute is present in the metadata
 func (mm *MemberMetadata) Has(attr MemberAttribute) bool {
@@ -129,6 +131,8 @@ func (mm *MemberMetadata) TryGet(attr MemberAttribute) (string, bool) {
 	val, ok := mm.attributes[attr]
 	return val, ok
 }
+
+*/
 
 // ForEach calls visitor for each attribute in the metadata.
 func (mm *MemberMetadata) ForEach(visitor func(MemberAttribute, string)) {

--- a/fact/member-metadata.go
+++ b/fact/member-metadata.go
@@ -9,12 +9,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// MemberAttribute is a single byte identifying some attribute of a member.
 type MemberAttribute byte
 
 const (
+	// MemberName is the friendly / display name to use for a peer
 	MemberName MemberAttribute = 'n'
 )
 
+// MemberMetadata represents a set of attributes and their values for a single
+// peer.
 type MemberMetadata struct {
 	attributes map[MemberAttribute]string
 }
@@ -51,6 +55,7 @@ func (mm *MemberMetadata) MarshalBinary() ([]byte, error) {
 	return buf[start:], nil
 }
 
+// DecodeFrom implements Decodable
 func (mm *MemberMetadata) DecodeFrom(lengthHint int, reader io.Reader) error {
 	var br io.ByteReader
 	var ok bool

--- a/fact/member-metadata.go
+++ b/fact/member-metadata.go
@@ -72,8 +72,10 @@ func (mm *MemberMetadata) DecodeFrom(lengthHint int, reader io.Reader) error {
 
 	payload := make([]byte, payloadLen)
 	l, err := reader.Read(payload)
-	if err != nil || uint64(l) != payloadLen {
+	if err != nil {
 		return errors.Wrap(err, "Unable to read member attributes payload")
+	} else if uint64(l) != payloadLen {
+		return errors.Errorf("Unable to read full member attributes payload, got %d of %d bytes", l, payloadLen)
 	}
 
 	mm.attributes = make(map[MemberAttribute]string)

--- a/fact/member-metadata.go
+++ b/fact/member-metadata.go
@@ -1,0 +1,107 @@
+package fact
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type MemberAttribute byte
+
+const (
+	MemberName MemberAttribute = 'n'
+)
+
+type MemberMetadata struct {
+	attributes map[MemberAttribute]string
+}
+
+var _ Value = &MemberMetadata{}
+
+// MarshalBinary implements BinaryEncoder
+func (mm *MemberMetadata) MarshalBinary() ([]byte, error) {
+	// start the buffer out with enough room for the length bytes that will be
+	// added at the end, plus a guess at the smallest possible size for the
+	// attribute data
+	buf := make([]byte, binary.MaxVarintLen16, binary.MaxVarintLen16+len(mm.attributes)*(1+binary.MaxVarintLen16))
+
+	// temp buffer and size for doing uvarint encodings
+	tmp := make([]byte, binary.MaxVarintLen64)
+	var l int
+
+	for a, v := range mm.attributes {
+		buf = append(buf, byte(a))
+		l = binary.PutUvarint(tmp, uint64(len(v)))
+		buf = append(buf, tmp[:l]...)
+		buf = append(buf, v...)
+	}
+
+	l = binary.PutUvarint(tmp, uint64(len(buf)-binary.MaxVarintLen16))
+	if l > binary.MaxVarintLen16 {
+		return nil, errors.Errorf("Member attributes length overflow: %d -> %d > 65535", len(mm.attributes), l)
+	}
+
+	// place the length bytes so that they abut the start of the data
+	start := binary.MaxVarintLen16 - l
+	copy(buf[start:], tmp[:l])
+
+	return buf[start:], nil
+}
+
+func (mm *MemberMetadata) DecodeFrom(lengthHint int, reader io.Reader) error {
+	var br io.ByteReader
+	var ok bool
+	if br, ok = reader.(io.ByteReader); !ok {
+		return errors.New("Cannot decode without a ByteReader")
+	}
+	payloadLen, err := binary.ReadUvarint(br)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read metadata length")
+	}
+	// TODO: trace the calls to ReadByte from the above, so that we can validate
+	// we don't exceed lengthHint. Not important as we expect lengthHint to be
+	// zero always for this value type
+
+	payload := make([]byte, payloadLen)
+	l, err := reader.Read(payload)
+	if err != nil || uint64(l) != payloadLen {
+		return errors.Wrap(err, "Unable to read member attributes payload")
+	}
+
+	mm.attributes = make(map[MemberAttribute]string)
+	for p := 0; p < len(payload); {
+		a := MemberAttribute(payload[p])
+		p++
+		al, n := binary.Uvarint(payload[p:])
+		if n <= 0 {
+			return errors.Errorf("varint encoding error in attribute at payload offset %d", p-n)
+		}
+		p += n
+		if p+int(al) > len(payload) {
+			return errors.Errorf("attribute length error at payload offset %d", p)
+		}
+		mm.attributes[a] = string(payload[p : p+int(al)])
+	}
+
+	return nil
+}
+
+func (mm *MemberMetadata) String() string {
+	// TODO: this could be better
+	if len(mm.attributes) == 0 {
+		return "(empty)"
+	}
+
+	ret := &strings.Builder{}
+	for a, v := range mm.attributes {
+		fmt.Fprintf(ret, "%c:%s", a, v)
+		break
+	}
+	if len(mm.attributes) > 1 {
+		fmt.Fprintf(ret, ",%d more", len(mm.attributes)-1)
+	}
+	return ret.String()
+}

--- a/fact/member-metadata.go
+++ b/fact/member-metadata.go
@@ -130,6 +130,13 @@ func (mm *MemberMetadata) TryGet(attr MemberAttribute) (string, bool) {
 	return val, ok
 }
 
+// ForEach calls visitor for each attribute in the metadata.
+func (mm *MemberMetadata) ForEach(visitor func(MemberAttribute, string)) {
+	for a, v := range mm.attributes {
+		visitor(a, v)
+	}
+}
+
 // BuildMemberMetadata creates a metadata structure with the MemberName
 // attribute set to the given value.
 func BuildMemberMetadata(name string) *MemberMetadata {

--- a/fact/member-metadata.go
+++ b/fact/member-metadata.go
@@ -86,9 +86,10 @@ func (mm *MemberMetadata) DecodeFrom(lengthHint int, reader io.Reader) error {
 		}
 		p += n
 		if p+int(al) > len(payload) {
-			return errors.Errorf("attribute length error at payload offset %d", p)
+			return errors.Errorf("attribute length error at payload offset %d: +%d>%d", p, al, len(payload))
 		}
 		mm.attributes[a] = string(payload[p : p+int(al)])
+		p += int(al)
 	}
 
 	return nil

--- a/fact/member-metadata_test.go
+++ b/fact/member-metadata_test.go
@@ -1,0 +1,57 @@
+package fact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemberMetadata_MarshalBinary(t *testing.T) {
+	type fields struct {
+		attributes map[MemberAttribute]string
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		want      []byte
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			"empty",
+			fields{map[MemberAttribute]string{}},
+			[]byte{0},
+			assert.NoError,
+		},
+		{
+			"one attribute, empty value",
+			fields{map[MemberAttribute]string{MemberName: ""}},
+			[]byte{
+				2, // content length
+				byte(MemberName),
+				0, // value length
+			},
+			assert.NoError,
+		},
+		{
+			"one attribute, ascii value",
+			fields{map[MemberAttribute]string{MemberName: "fred"}},
+			[]byte{
+				6,
+				byte(MemberName),
+				4,
+				'f', 'r', 'e', 'd',
+			},
+			assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mm := &MemberMetadata{
+				attributes: tt.fields.attributes,
+			}
+			got, err := mm.MarshalBinary()
+			tt.assertion(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/fact/member-metadata_test.go
+++ b/fact/member-metadata_test.go
@@ -150,3 +150,48 @@ func TestMemberMetadata_DecodeFrom(t *testing.T) {
 		})
 	}
 }
+
+func TestMemberMetadata_String(t *testing.T) {
+	type fields struct {
+		attributes map[MemberAttribute]string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantOne []string
+	}{
+		{
+			"empty",
+			fields{map[MemberAttribute]string{}},
+			[]string{"(empty)"},
+		},
+		{
+			"one",
+			fields{map[MemberAttribute]string{
+				MemberName: "foo",
+			}},
+			[]string{"n:foo"},
+		},
+		{
+			"many",
+			fields{map[MemberAttribute]string{
+				MemberName:           "foo",
+				MemberAttribute('a'): "bar",
+				MemberAttribute('b'): "baz",
+			}},
+			[]string{
+				"n:foo,+2",
+				"a:bar,+2",
+				"b:baz,+2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mm := &MemberMetadata{
+				attributes: tt.fields.attributes,
+			}
+			assert.Contains(t, tt.wantOne, mm.String())
+		})
+	}
+}

--- a/fact/member-metadata_test.go
+++ b/fact/member-metadata_test.go
@@ -2,7 +2,6 @@ package fact
 
 import (
 	"bytes"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -89,10 +88,6 @@ func TestMemberMetadata_MarshalBinary(t *testing.T) {
 func TestMemberMetadata_DecodeFrom(t *testing.T) {
 	type fields struct {
 		attributes map[MemberAttribute]string
-	}
-	type args struct {
-		lengthHint int
-		reader     io.Reader
 	}
 	tests := []struct {
 		name       string

--- a/fact/member-metadata_test.go
+++ b/fact/member-metadata_test.go
@@ -1,6 +1,8 @@
 package fact
 
 import (
+	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,35 +13,63 @@ func TestMemberMetadata_MarshalBinary(t *testing.T) {
 		attributes map[MemberAttribute]string
 	}
 	tests := []struct {
-		name      string
-		fields    fields
-		want      []byte
+		name   string
+		fields fields
+		// due to map orderings, need multiple want options sometimes here
+		wantOneOf [][]byte
 		assertion assert.ErrorAssertionFunc
 	}{
 		{
 			"empty",
 			fields{map[MemberAttribute]string{}},
-			[]byte{0},
+			[][]byte{{0}},
 			assert.NoError,
 		},
 		{
 			"one attribute, empty value",
 			fields{map[MemberAttribute]string{MemberName: ""}},
-			[]byte{
+			[][]byte{{
 				2, // content length
 				byte(MemberName),
 				0, // value length
-			},
+			}},
 			assert.NoError,
 		},
 		{
 			"one attribute, ascii value",
 			fields{map[MemberAttribute]string{MemberName: "fred"}},
-			[]byte{
+			[][]byte{{
 				6,
 				byte(MemberName),
 				4,
 				'f', 'r', 'e', 'd',
+			}},
+			assert.NoError,
+		},
+		{
+			"two attributes, ascii values",
+			fields{map[MemberAttribute]string{
+				MemberName:           "fred",
+				MemberAttribute('z'): "foo",
+			}},
+			[][]byte{
+				{
+					11,
+					byte(MemberName),
+					4,
+					'f', 'r', 'e', 'd',
+					'z',
+					3,
+					'f', 'o', 'o',
+				}, {
+					11,
+					'z',
+					3,
+					'f', 'o', 'o',
+					byte(MemberName),
+					4,
+					'f', 'r', 'e', 'd',
+				},
 			},
 			assert.NoError,
 		},
@@ -51,7 +81,77 @@ func TestMemberMetadata_MarshalBinary(t *testing.T) {
 			}
 			got, err := mm.MarshalBinary()
 			tt.assertion(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.Contains(t, tt.wantOneOf, got)
+		})
+	}
+}
+
+func TestMemberMetadata_DecodeFrom(t *testing.T) {
+	type fields struct {
+		attributes map[MemberAttribute]string
+	}
+	type args struct {
+		lengthHint int
+		reader     io.Reader
+	}
+	tests := []struct {
+		name       string
+		data       []byte
+		wantFields fields
+		assertion  assert.ErrorAssertionFunc
+	}{
+		{
+			"empty",
+			[]byte{0},
+			fields{map[MemberAttribute]string{}},
+			assert.NoError,
+		},
+		{
+			"one attribute, empty value",
+			[]byte{
+				2, // content length
+				byte(MemberName),
+				0, // value length
+			},
+			fields{map[MemberAttribute]string{MemberName: ""}},
+			assert.NoError,
+		},
+		{
+			"one attribute, ascii value",
+			[]byte{
+				6,
+				byte(MemberName),
+				4,
+				'f', 'r', 'e', 'd',
+			},
+			fields{map[MemberAttribute]string{MemberName: "fred"}},
+			assert.NoError,
+		},
+		{
+			"two attributes, ascii values",
+			[]byte{
+				11,
+				byte(MemberName),
+				4,
+				'f', 'r', 'e', 'd',
+				'z',
+				3,
+				'f', 'o', 'o',
+			},
+			fields{map[MemberAttribute]string{
+				MemberName:           "fred",
+				MemberAttribute('z'): "foo",
+			}},
+			assert.NoError,
+		},
+		// TODO: encoding error tests
+		// TODO: attribute repeat test with error
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mm := &MemberMetadata{}
+			tt.assertion(t, mm.DecodeFrom(0, bytes.NewBuffer(tt.data)))
+			assert.Equal(t, tt.wantFields.attributes, mm.attributes)
 		})
 	}
 }

--- a/fact/parse.go
+++ b/fact/parse.go
@@ -48,6 +48,11 @@ var decodeHints map[Attribute]decodeHinter = map[Attribute]decodeHinter{
 		f.Value = &EmptyValue{}
 		return 0
 	},
+	AttributeMemberMetadata: func(f *Fact) int {
+		f.Subject = &PeerSubject{}
+		f.Value = &MemberMetadata{}
+		return 0
+	},
 
 	AttributeSignedGroup: func(f *Fact) int {
 		f.Subject = &PeerSubject{}

--- a/server/device.go
+++ b/server/device.go
@@ -52,13 +52,18 @@ func (s *LinkServer) collectFacts(dev *wgtypes.Device, now time.Time) (ret []*fa
 	// these may duplicate other known facts, higher layers will dedupe
 	for pk, pc := range s.config.Peers {
 		// statically configured peers are always valid members
-		// TODO: replace this with an AttributeMemberMetadata if we have metadata
-		ret = append(ret, &fact.Fact{
+		f := &fact.Fact{
 			Attribute: fact.AttributeMember,
 			Subject:   &fact.PeerSubject{Key: pk},
 			Value:     &fact.EmptyValue{},
 			Expires:   expires,
-		})
+		}
+		if len(pc.Name) > 0 {
+			// we have metadata, replace it with a metadata member fact
+			f.Attribute = fact.AttributeMemberMetadata
+			f.Value = fact.BuildMemberMetadata(pc.Name)
+		}
+		ret = append(ret, f)
 		ret = s.handlePeerConfigAllowedIPs(pk, pc, expires, ret)
 		// skip endpoint lookups for self
 		// if other peers need these as static facts, they would have it in their config

--- a/server/device.go
+++ b/server/device.go
@@ -52,6 +52,7 @@ func (s *LinkServer) collectFacts(dev *wgtypes.Device, now time.Time) (ret []*fa
 	// these may duplicate other known facts, higher layers will dedupe
 	for pk, pc := range s.config.Peers {
 		// statically configured peers are always valid members
+		// TODO: replace this with an AttributeMemberMetadata if we have metadata
 		ret = append(ret, &fact.Fact{
 			Attribute: fact.AttributeMember,
 			Subject:   &fact.PeerSubject{Key: pk},

--- a/server/peer-config.go
+++ b/server/peer-config.go
@@ -79,7 +79,7 @@ func (s *LinkServer) collectPeerFlags(
 	for i := range dev.Peers {
 		peer := &dev.Peers[i]
 		localPeers[peer.PublicKey] = true
-		_, ok := factsByPeer[peer.PublicKey]
+		peerFacts, ok := factsByPeer[peer.PublicKey]
 		// if we have no info about a local peer, flag it for deletion
 		if !ok && !validPeers[peer.PublicKey] {
 			removePeer[peer.PublicKey] = true
@@ -89,7 +89,7 @@ func (s *LinkServer) collectPeerFlags(
 		// is still valid now
 		newAlive, aliveUntil, bootID := s.peerKnowledge.peerAlive(peer.PublicKey)
 		ps, _ := s.peerConfig.Get(peer.PublicKey)
-		ps = ps.Update(peer, s.peerName(peer.PublicKey), newAlive, aliveUntil, bootID, now)
+		ps = ps.Update(peer, s.peerConfigName(peer.PublicKey), newAlive, aliveUntil, bootID, now, peerFacts)
 		s.peerConfig.Set(peer.PublicKey, ps)
 	}
 

--- a/server/peer-config.go
+++ b/server/peer-config.go
@@ -98,7 +98,9 @@ func (s *LinkServer) collectPeerFlags(
 		// don't flag for removal anything already identified as valid
 		if validPeers[peer] {
 			continue
-		} else if fact.SliceHas(factGroup, func(f *fact.Fact) bool { return f.Attribute == fact.AttributeMember }) {
+		} else if fact.SliceHas(factGroup, func(f *fact.Fact) bool {
+			return f.Attribute == fact.AttributeMember || f.Attribute == fact.AttributeMemberMetadata
+		}) {
 			validPeers[peer] = true
 		} else {
 			removePeer[peer] = true

--- a/server/udp-inbound_test.go
+++ b/server/udp-inbound_test.go
@@ -361,8 +361,9 @@ func TestLinkServer_processSignedGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &LinkServer{
-				config: &config.Server{},
-				signer: tt.fields.signer,
+				config:     &config.Server{},
+				signer:     tt.fields.signer,
+				peerConfig: newPeerConfigSet(),
 			}
 			// we make a channel with a huge buffer so that we can do this linearly
 			// and not have goroutines and waits

--- a/server/udp-outbound_test.go
+++ b/server/udp-outbound_test.go
@@ -156,6 +156,7 @@ func TestLinkServer_shouldSendTo(t *testing.T) {
 			s := &LinkServer{
 				config:      tt.fields.config,
 				stateAccess: &sync.Mutex{},
+				peerConfig:  newPeerConfigSet(),
 			}
 			assert.Equal(t, tt.want, s.shouldSendTo(tt.args.p))
 		})
@@ -477,6 +478,7 @@ func TestLinkServer_broadcastFacts(t *testing.T) {
 				signer:        tt.fields.signer,
 
 				stateAccess: &sync.Mutex{},
+				peerConfig:  newPeerConfigSet(),
 
 				FactTTL:     DefaultFactTTL,
 				ChunkPeriod: DefaultChunkPeriod,

--- a/server/util.go
+++ b/server/util.go
@@ -53,7 +53,14 @@ func (s *LinkServer) formatFacts(
 	}
 	str.WriteString("\nCurrent peers:")
 	s.peerConfig.ForEach(func(k wgtypes.Key, pcs *apply.PeerConfigState) {
-		fmt.Fprintf(&str, "\nPeer %s is %s", s.peerName(k), pcs.Describe(now))
+		peerName := s.peerConfigName(k)
+		if len(peerName) == 0 {
+			peerName, _ = pcs.TryGetMetadata(fact.MemberName)
+			if len(peerName) == 0 {
+				peerName = k.String()
+			}
+		}
+		fmt.Fprintf(&str, "\nPeer %s is %s", peerName, pcs.Describe(now))
 	})
 	str.WriteString("\nSelf: ")
 	str.WriteString(s.Describe())

--- a/server/util.go
+++ b/server/util.go
@@ -13,8 +13,17 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
-func (s *LinkServer) peerName(peer wgtypes.Key) string {
+func (s *LinkServer) peerConfigName(peer wgtypes.Key) string {
 	return s.config.Peers.Name(peer)
+}
+
+func (s *LinkServer) peerName(peer wgtypes.Key) string {
+	ret := s.peerConfigName(peer)
+	if len(ret) == 0 {
+		pcs, _ := s.peerConfig.Get(peer)
+		ret, _ = pcs.TryGetMetadata(fact.MemberName)
+	}
+	return ret
 }
 
 func (s *LinkServer) formatFacts(

--- a/server/util.go
+++ b/server/util.go
@@ -19,11 +19,15 @@ func (s *LinkServer) peerConfigName(peer wgtypes.Key) string {
 
 func (s *LinkServer) peerName(peer wgtypes.Key) string {
 	ret := s.peerConfigName(peer)
-	if len(ret) == 0 {
-		pcs, _ := s.peerConfig.Get(peer)
-		ret, _ = pcs.TryGetMetadata(fact.MemberName)
+	if len(ret) > 0 {
+		return ret
 	}
-	return ret
+	pcs, _ := s.peerConfig.Get(peer)
+	ret, _ = pcs.TryGetMetadata(fact.MemberName)
+	if len(ret) > 0 {
+		return ret
+	}
+	return peer.String()
 }
 
 func (s *LinkServer) formatFacts(

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -41,6 +41,7 @@ func TestLinkServer_formatFacts(t *testing.T) {
 		time.Time{},
 		nil,
 		now,
+		nil,
 	)
 
 	type fields struct {

--- a/server/utils_test.go
+++ b/server/utils_test.go
@@ -36,6 +36,7 @@ func makePCS(t *testing.T, healthy, alive, aliveLong bool) *apply.PeerConfigStat
 		until,
 		nil,
 		now,
+		nil,
 	)
 	// make sure it worked
 	assert.Equal(t, healthy, ret.IsHealthy())

--- a/trust/trust.go
+++ b/trust/trust.go
@@ -98,6 +98,8 @@ func ShouldAccept(attr fact.Attribute, known bool, level *Level) bool {
 		threshold = AllowedIPs
 
 	case fact.AttributeMember:
+		fallthrough
+	case fact.AttributeMemberMetadata:
 		threshold = Membership
 
 	default:

--- a/trust/trust_test.go
+++ b/trust/trust_test.go
@@ -41,6 +41,7 @@ func TestShouldAccept(t *testing.T) {
 		fact.AttributeAllowedCidrV4,
 		fact.AttributeAllowedCidrV6,
 		fact.AttributeMember,
+		fact.AttributeMemberMetadata,
 	}
 	invalidAttrs := []fact.Attribute{
 		fact.AttributeUnknown,
@@ -59,6 +60,7 @@ func TestShouldAccept(t *testing.T) {
 	}
 	memberAttr := []fact.Attribute{
 		fact.AttributeMember,
+		fact.AttributeMemberMetadata,
 	}
 	allLevels := []Level{Untrusted, Endpoint, AllowedIPs, Membership, DelegateTrust}
 


### PR DESCRIPTION
Allows trust source to provide peer names so that clients don't need to have config shipped to them (with the implications on inability to revoke peers) that carries.