### PR TITLE
fix: don't send membership data for offline peers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,13 @@
 				"--iface=wg0",
 				"--debug"
 			]
+		},
+		{
+			"name": "Test current package",
+			"type": "go",
+			"request": "launch",
+			"mode": "test",
+			"program": "${fileDirname}",
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,9 +20,9 @@
 			"name": "Run for real",
 			"type": "go",
 			"request": "launch",
-			"mode": "debug",
+			"mode": "exec",
 			"preLaunchTask": "build app",
-			"program": "${workspaceFolder}",
+			"program": "${workspaceFolder}/wirelink",
 			"env": {
 				"WIRELINK_DEBUG_AS_ROOT": "true"
 			},

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,5 +87,16 @@
 	"go.formatTool": "goreturns",
 	"go.gotoSymbol.includeImports": true,
 	"files.insertFinalNewline": true,
-	"files.trimFinalNewlines": true
+	"files.trimFinalNewlines": true,
+	"go.delveConfig": {
+		"dlvLoadConfig": {
+			// "followPointers": true,
+			// "maxVariableRecurse": 1,
+			"maxStringLen": 256,
+			// "maxArrayValues": 64,
+			// "maxStructFields": -1
+		},
+		// "apiVersion": 2,
+		// "showGlobalVariables": false
+	}
 }

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ coverage.out: generate
 cover: coverage.out
 coverage.html: coverage.out
 	go tool cover -html=coverage.out -o=coverage.html
+htmlcover: coverage.html
 
 run: generate
 	go run -exec sudo .

--- a/fact/fact-set.go
+++ b/fact/fact-set.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/fastcat/wirelink/util"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 // Key is a comparable version of the subject, attribute, and value of a Fact
@@ -19,7 +20,11 @@ type Key struct {
 }
 
 func (k *Key) String() string {
-	return fmt.Sprintf("[a:%c s:%s v:%s]", k.Attribute, k.subject, k.value)
+	if len(k.subject) == wgtypes.KeyLen {
+		kk, _ := wgtypes.NewKey([]byte(k.subject))
+		return fmt.Sprintf("[a:%q s:%s v:%q]", k.Attribute, kk, k.value)
+	}
+	return fmt.Sprintf("[a:%q s:%q v:%q]", k.Attribute, k.subject, k.value)
 }
 
 // KeyOf returns the FactKey for a Fact

--- a/fact/fact-set.go
+++ b/fact/fact-set.go
@@ -1,6 +1,7 @@
 package fact
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -15,6 +16,10 @@ type Key struct {
 	// so instead convert to bytes and then coerce that to a "string"
 	subject string
 	value   string
+}
+
+func (k *Key) String() string {
+	return fmt.Sprintf("[a:%c s:%s v:%s]", k.Attribute, k.subject, k.value)
 }
 
 // KeyOf returns the FactKey for a Fact

--- a/fact/fact-set_test.go
+++ b/fact/fact-set_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/fastcat/wirelink/internal/testutils"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,6 +29,51 @@ func TestFactKeyEquality(t *testing.T) {
 	factKey2 := KeyOf(&fact2)
 
 	assert.Exactly(t, factKey1, factKey2, "Keys for same fact should be equal")
+}
+
+func TestKey_String(t *testing.T) {
+	type fields struct {
+		Attribute Attribute
+		subject   string
+		value     string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			"zeros",
+			fields{
+				Attribute: AttributeUnknown,
+				subject:   "",
+				value:     "",
+			},
+			`[a:'\x00' s:"" v:""]`,
+		},
+		{
+			"semi-real",
+			fields{
+				Attribute: AttributeMember,
+				subject: string([]byte{
+					0xe4, 0x25, 0x0c, 0xb1, 0xc9, 0x4b, 0xcd, 0x4e, 0xeb, 0x4e, 0x09, 0x06, 0xab, 0x81, 0x8a, 0x3a,
+					0x8c, 0x05, 0xe2, 0x3c, 0xfd, 0x6e, 0x38, 0x4f, 0xca, 0x8d, 0x5b, 0x73, 0xef, 0xb1, 0x0b, 0x18,
+				}),
+				value: "xyzzy",
+			},
+			`[a:'m' s:5CUMsclLzU7rTgkGq4GKOowF4jz9bjhPyo1bc++xCxg= v:"xyzzy"]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &Key{
+				Attribute: tt.fields.Attribute,
+				subject:   tt.fields.subject,
+				value:     tt.fields.value,
+			}
+			assert.Equal(t, tt.want, k.String())
+		})
+	}
 }
 
 func TestMergeList(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	golang.zx2c4.com/wireguard v0.0.20200320
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,8 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
-	golang.org/x/net v0.0.0-20200927032502-5d4f70055728 // indirect
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20200926100807-9d91bd62050c // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	golang.zx2c4.com/wireguard v0.0.20200320
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20200609130330-bd2cb7843e1b

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
+golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ golang.org/x/net v0.0.0-20191003171128-d98b1b443823/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200927032502-5d4f70055728 h1:5wtQIAulKU5AbLQOkjxl32UufnIOqgBX72pS0AV14H0=
-golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -299,8 +299,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -325,9 +325,8 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200926100807-9d91bd62050c h1:38q6VNPWR010vN82/SB121GujZNIfAUb4YttE2rhGuc=
-golang.org/x/sys v0.0.0-20200926100807-9d91bd62050c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/server/udp-outbound.go
+++ b/server/udp-outbound.go
@@ -43,7 +43,7 @@ func (s *LinkServer) broadcastFactUpdatesOnce(newFacts []*fact.Fact, dev *wgtype
 	filteredFacts := make([]*fact.Fact, 0, len(newFacts))
 	for _, f := range newFacts {
 		switch f.Attribute {
-		case fact.AttributeMember, fact.AttributeMemberMetadata:
+		case fact.AttributeMember, fact.AttributeMemberMetadata, fact.AttributeAllowedCidrV4, fact.AttributeAllowedCidrV6, fact.AttributeEndpointV4, fact.AttributeEndpointV6:
 			ps := f.Subject.(*fact.PeerSubject)
 			if pcs, ok := s.peerConfig.Get(ps.Key); ok && !pcs.IsAlive() && !pcs.IsHealthy() {
 				// peer is known but dead, don't send membership data

--- a/util/ip.go
+++ b/util/ip.go
@@ -51,8 +51,12 @@ func IsGloballyRoutable(ip net.IP) bool {
 		// TODO: more ranges?
 	}
 	if ip6 := ip.To16(); ip6 != nil {
-		// fc00::/7 ~ ipv6 equivalent of 10/8-ish
+		// fc00::/7 ~ unique local addr ipv6 equivalent of 10/8-ish
 		if ip6[0] == 0xfc || ip6[0] == 0xfd {
+			return false
+		}
+		// fec0::/10 ~ deprecated site-local
+		if ip6[0] == 0xfe && ip6[1] >= 0xc0 {
 			return false
 		}
 	}


### PR DESCRIPTION
keeps leaf configs cleaner by removing offline peers, they should come back
when they reconnect to a trust source, and thus membership data starts being
sent again