### PR TITLE
fix: avoid peer endpoints that would route through the tunnel

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-11]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/apply/state_test.go
+++ b/apply/state_test.go
@@ -492,7 +492,7 @@ func TestPeerConfigState_NextEndpoint(t *testing.T) {
 			// if tt.fields.nil {
 			// 	pcs = nil
 			// }
-			got := pcs.NextEndpoint(tt.args.peerFacts, now)
+			got := pcs.NextEndpoint("test", tt.args.peerFacts, now, nil)
 			assert.Equal(t, tt.want, got)
 			if tt.want != nil {
 				wantMap := make(map[string]time.Time, len(tt.fields.endpointLastUsed))

--- a/fact/parse.go
+++ b/fact/parse.go
@@ -16,7 +16,7 @@ import (
 type decodeHinter = func(*Fact) (valueLength int)
 
 // decodeHints provides a lookup table for how to decode each valid attribute value
-var decodeHints map[Attribute]decodeHinter = map[Attribute]decodeHinter{
+var decodeHints = map[Attribute]decodeHinter{
 	AttributeAlive: func(f *Fact) int {
 		// Modern ping packet with boot id embedded in value
 		f.Subject = &PeerSubject{}

--- a/server/device.go
+++ b/server/device.go
@@ -174,3 +174,58 @@ func (s *LinkServer) handlePeerConfigEndpoints(
 	}
 	return
 }
+
+func (s *LinkServer) updateInterfaceCache() {
+	// TODO: DeviceFacts loads this info too
+	s.stateAccess.Lock()
+	defer s.stateAccess.Unlock()
+
+	ifaces, err := s.net.Interfaces()
+	if err != nil {
+		log.Error("unable to load network interfaces: %v", err)
+		// don't abort the caller, continue with whatever info we have from last time
+		return
+	}
+	s.tunnelIPNets = s.tunnelIPNets[:0]
+	s.hostIPNets = s.hostIPNets[:0]
+	for _, iface := range ifaces {
+		if addrs, err := iface.Addrs(); err != nil {
+			log.Error("unable to fetch addresses from %s: %v", iface.Name(), err)
+		} else if iface.Name() == s.config.Iface {
+			s.tunnelIPNets = append(s.tunnelIPNets, addrs...)
+		} else {
+			s.hostIPNets = append(s.hostIPNets, addrs...)
+		}
+	}
+}
+
+func (s *LinkServer) isUsablePeerEndpointLocked(f *fact.Fact) bool {
+	ipv, ok := f.Value.(*fact.IPPortValue)
+	if !ok {
+		return false
+	}
+
+	// this must be called with stateAccess Locked!
+	// s.stateAccess.Lock()
+	// defer s.stateAccess.Unlock()
+
+	// a bad endpoint is one that matches a tunnel network but not a host network,
+	// i.e. it would definitely go through the tunnel.
+	isGood := true
+	for _, ipn := range s.tunnelIPNets {
+		if ipn.Contains(ipv.IP) {
+			isGood = false
+			break
+		}
+	}
+	if isGood {
+		return true
+	}
+	for _, ipn := range s.hostIPNets {
+		if ipn.Contains(ipv.IP) {
+			isGood = true
+			break
+		}
+	}
+	return isGood
+}

--- a/server/peer-config.go
+++ b/server/peer-config.go
@@ -396,7 +396,7 @@ func (s *LinkServer) configurePeer(
 		}
 
 		if state.TimeForNextEndpoint() {
-			nextEndpoint := state.NextEndpoint(facts, now)
+			nextEndpoint := state.NextEndpoint(peerName, facts, now, s.isUsablePeerEndpointLocked)
 			if nextEndpoint == nil {
 				log.Debug("Time for new EP for %s, but none known", peerName)
 			} else if util.UDPEqualIPPort(nextEndpoint, peer.Endpoint) {

--- a/server/udp-inbound.go
+++ b/server/udp-inbound.go
@@ -229,6 +229,7 @@ func (s *LinkServer) processOneChunk(
 			newFactsChunk = append(newFactsChunk, f)
 		}
 	}
+	s.updateInterfaceCache()
 	dev, err := s.deviceState()
 	if err != nil {
 		// this probably means the interface is down

--- a/server/udp-server.go
+++ b/server/udp-server.go
@@ -50,9 +50,18 @@ type LinkServer struct {
 
 	// TODO: these should not be exported like this
 	// this is temporary to simplify acceptance tests
+
 	FactTTL     time.Duration
 	ChunkPeriod time.Duration
 	AlivePeriod time.Duration
+
+	// cache of local interface addresses, used to determine if a peer endpoint is
+	// usable, to avoid trying to contact a peer through the tunnel itself.
+
+	// IPNets assigned to the tunnel
+	tunnelIPNets []net.IPNet
+	// IPNets for local network interfaces other than the tunnel
+	hostIPNets []net.IPNet
 }
 
 // MaxChunk is the max number of packets to receive before processing them


### PR DESCRIPTION
e.g. LAN endpoints are usable when "home", but route through the tunnel when "away" and create breakage
